### PR TITLE
Patch 2.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ env:
   NXF_ANSI_LOG: false
 
 jobs:
+  free-disk-space:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool_cache: true
+
   test:
     name: Run pipeline with test data
     # Only run on push if this is the nf-core dev branch (merged PRs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           - NXF_VER: "23.04.4"
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check out test data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: NorwegianVeterinaryInstitute/ALPPACA
           ref: testdata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,6 @@ env:
   NXF_ANSI_LOG: false
 
 jobs:
-  free-disk-space:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool_cache: true
-
   test:
     name: Run pipeline with test data
     # Only run on push if this is the nf-core dev branch (merged PRs)
@@ -32,6 +24,11 @@ jobs:
           # Test pipeline minimum Nextflow version
           - NXF_VER: "23.04.4"
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool_cache: true
+
       - name: Check out pipeline code
         uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## Version 2.3.1
+- Updated the version of ParSNP to 2.0.3, as of issue #112
+- Bumped software versions in all reports
+- Added gffs as optional output with the command `--output_gffs`, as of issue #113
+
+
 ## Version 2.3.0
 - Gubbins have been updated to version 3.3.2, and the `--seed` parameter now sets the seed for both IQ-Tree and Gubbins, as of isse #109
 - Added Bakta as a replacement to Prokka in the core gene track, as of issue #54

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Version 2.3.1
 - Updated the version of ParSNP to 2.0.3, as of issue #112
+- Updated Panaroo to version 1.3.4
 - Bumped software versions in all reports
 - Added gffs as optional output with the command `--output_gffs`, as of issue #113
 

--- a/bin/cgmlst_report.Rmd
+++ b/bin/cgmlst_report.Rmd
@@ -277,7 +277,7 @@ of ALPPACA.
 ```{r, message=FALSE, warning=FALSE}
 tool_data <- data.frame(
   Tool = c("ChewBBACA","R"),
-  Version = c("3.1.2","4.1.2")
+  Version = c("3.3.1","4.1.2")
 )
 
 tool_data %>%

--- a/bin/core_gene_report.Rmd
+++ b/bin/core_gene_report.Rmd
@@ -189,16 +189,16 @@ lapply(packages, function(x) clean_pkg_version(x)) %>%
 These are the tools used to run the analysis within the core genome workflow of ALPPACA.
 ```{r, message=FALSE, warning=FALSE}
 tool_data <- data.frame(
-  Tool = c("Prokka",
+  Tool = c("Bakta",
            "Panaroo",
            "Snp-dists",
            "Snp-sites",
            "IQTree"),
-  Version = c("1.14.6",
+  Version = c("1.9.1",
               "1.2.9",
               "0.8.2",
               "2.5.1",
-              "2.2.0.3")
+              "2.2.6")
 )
 tool_data %>%
   kbl() %>%

--- a/bin/core_gene_report.Rmd
+++ b/bin/core_gene_report.Rmd
@@ -195,7 +195,7 @@ tool_data <- data.frame(
            "Snp-sites",
            "IQTree"),
   Version = c("1.9.1",
-              "1.2.9",
+              "1.3.4",
               "0.8.2",
               "2.5.1",
               "2.2.6")

--- a/bin/core_genome_report.Rmd
+++ b/bin/core_genome_report.Rmd
@@ -224,12 +224,12 @@ tool_data <- data.frame(
            "Snp-dists",
            "Snp-sites",
            "IQTree"),
-  Version = c("1.6.1",
-              "3.2.0",
-              "0.5",
+  Version = c("2.0.3",
+              "3.3.2",
+              "0.5--1",
               "0.8.2",
               "2.5.1",
-              "2.2.0.3")
+              "2.2.6")
 )
 tool_data %>%
   kbl() %>%

--- a/bin/mapping_report.Rmd
+++ b/bin/mapping_report.Rmd
@@ -196,11 +196,11 @@ tool_data <- data.frame(
            "Snp-sites",
            "IQTree"),
   Version = c("4.6.0",
-              "3.2.0",
+              "3.3.2",
               "0.5",
               "0.8.2",
               "2.5.1",
-              "2.2.0.3")
+              "2.2.6")
 )
 tool_data %>%
   kbl() %>%

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -247,7 +247,7 @@ process {
                                 path:           { "${params.out_dir}/results" },
                                 mode:           params.publish_dir_mode,
                                 pattern:        "*png",
-                        ],
+                        ]
 		]
 	}
 	withName: 'PANAROO_PANGENOME' {
@@ -327,6 +327,15 @@ process {
                                 pattern:        "bakta.version"
 		]
 	}
+	if(params.output_gffs) {
+                withName: 'BAKTA' {
+                        publishDir = [
+                                path:           { "${params.out_dir}/results/gffs" },
+                                mode:           params.publish_dir_mode,
+                                pattern:        "*gff3"
+                        ]
+                }
+        }
 	withName: 'REPORT_ANI' {
 		publishDir = [
 			[

--- a/modules/PANAROO.nf
+++ b/modules/PANAROO.nf
@@ -1,6 +1,6 @@
 process PANAROO_QC {
-	conda (params.enable_conda ? 'bioconda::panaroo=1.2.9' : null)
-	container 'quay.io/biocontainers/panaroo:1.2.9--pyhdfd78af_0'
+	conda (params.enable_conda ? 'bioconda::panaroo=1.3.4' : null)
+	container 'quay.io/biocontainers/panaroo:1.3.4--pyhdfd78af_0'
 
 	label 'process_high_memory_time'
 
@@ -22,8 +22,8 @@ process PANAROO_QC {
 }
 
 process PANAROO_PANGENOME {
-	conda (params.enable_conda ? 'bioconda::panaroo=1.2.9' : null)
-        container 'quay.io/biocontainers/panaroo:1.2.9--pyhdfd78af_0'
+	conda (params.enable_conda ? 'bioconda::panaroo=1.3.4' : null)
+        container 'quay.io/biocontainers/panaroo:1.3.4--pyhdfd78af_0'
 
 	label 'process_high_cpu_time'
 

--- a/modules/PARSNP.nf
+++ b/modules/PARSNP.nf
@@ -1,6 +1,6 @@
 process PARSNP {
-	conda (params.enable_conda ? 'bioconda::parsnp=1.7.4' : null)
-	container 'quay.io/biocontainers/parsnp:1.7.4--hdcf5f25_2'
+	conda (params.enable_conda ? 'bioconda::parsnp=2.0.0' : null)
+	container 'quay.io/biocontainers/parsnp:2.0.3--hdcf5f25_0'
 
 	label 'process_long'
 
@@ -15,8 +15,11 @@ process PARSNP {
         script:
         """
 	parsnp --version > parsnp.version
-        parsnp -d *.fasta -p 4 --skip-phylogeny -u -o results -r $params.parsnp_ref -v -c &> parsnp.log
-	mv results/* .
+        parsnp -d *.fasta -p $task.cpus --skip-phylogeny -u -o results -r $params.parsnp_ref -v -c &> parsnp.log
+	mv results/log/parsnpAligner.log .
+	mv results/parsnp.ggr .
+	mv results/parsnp.xmfa .
+	mv results/parsnp.unalign . 
 	harvesttools -x *xmfa -M parsnp_alignment.fasta
         """
 }

--- a/modules/PARSNP.nf
+++ b/modules/PARSNP.nf
@@ -1,5 +1,5 @@
 process PARSNP {
-	conda (params.enable_conda ? 'bioconda::parsnp=2.0.0' : null)
+	conda (params.enable_conda ? 'bioconda::parsnp=2.0.3' : null)
 	container 'quay.io/biocontainers/parsnp:2.0.3--hdcf5f25_0'
 
 	label 'process_long'

--- a/nextflow.config
+++ b/nextflow.config
@@ -157,7 +157,7 @@ manifest {
     description     = 'A Tool for Prokaryotic Phylogeny and Clustering Analysis'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.4'
-    version         = '2.3.0'
+    version         = '2.3.1'
 }
 
 // Define variables to prevent local R libraries from conflicting with the container

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params {
 
 	// Core gene analysis options
 	bakta_db		= null
+	output_gffs		= null
 	refdb			= null
 	clean_mode		= "moderate"
 	identity_threshold	= 0.98


### PR DESCRIPTION
Update to version 2.3.1, involved the following:
- Updated the version of ParSNP to 2.0.3, as of issue #112
- Updated Panaroo to version 1.3.4
- Bumped software versions in all reports
- Added gffs as optional output with the command --output_gffs, as of issue #113
- Fixed CI test disk space issue